### PR TITLE
[FEAT/#63] 토큰 관리 로직 추가

### DIFF
--- a/app/src/main/java/com/napzak/market/core/local/DataStoreModule.kt
+++ b/app/src/main/java/com/napzak/market/core/local/DataStoreModule.kt
@@ -1,0 +1,24 @@
+package com.napzak.market.core.local
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    private const val TOKEN_PREFERENCE_NAME = "token_preference"
+
+    private val Context.provideDataStore by preferencesDataStore(TOKEN_PREFERENCE_NAME)
+
+    @Provides
+    @Singleton
+    fun provideTokenDataStore(
+        @ApplicationContext context: Context
+    ) = TokenDataStore(context.provideDataStore)
+}

--- a/app/src/main/java/com/napzak/market/core/local/TokenDataStore.kt
+++ b/app/src/main/java/com/napzak/market/core/local/TokenDataStore.kt
@@ -1,0 +1,36 @@
+package com.napzak.market.core.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class TokenDataStore @Inject constructor(
+    private val preferenceDataStore: DataStore<Preferences>
+) {
+    suspend fun getAccessToken(): String? = preferenceDataStore.data.map { preferences ->
+        preferences[preferencesTokenKey] ?: TEMPORARY_TOKEN
+    }.firstOrNull()
+
+    suspend fun setAccessToken(token: String) {
+        preferenceDataStore.edit { preferences ->
+            preferences[preferencesTokenKey] = token
+        }
+    }
+
+    suspend fun clearInfo() {
+        preferenceDataStore.edit { preferences ->
+            preferences.remove(preferencesTokenKey)
+        }
+    }
+
+    companion object {
+        private const val TOKEN_KEY = "token_key"
+        private val preferencesTokenKey = stringPreferencesKey(TOKEN_KEY)
+
+        private const val TEMPORARY_TOKEN = ""
+    }
+}

--- a/app/src/main/java/com/napzak/market/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/napzak/market/core/network/AuthInterceptor.kt
@@ -1,0 +1,37 @@
+package com.napzak.market.core.network
+
+import com.napzak.market.core.local.TokenDataStore
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        val authRequest = runBlocking {
+            val token = tokenDataStore.getAccessToken()
+            if (token?.isNotBlank() == true) {
+                originalRequest.newBuilder().newAuthBuilder().build()
+            } else {
+                originalRequest
+            }
+        }
+
+        val response = chain.proceed(authRequest)
+
+        return response
+    }
+
+    private suspend fun Request.Builder.newAuthBuilder() =
+        this.addHeader(AUTHORIZATION, "$BEARER ${tokenDataStore.getAccessToken()}")
+
+    companion object {
+        private const val BEARER = "Bearer"
+        private const val AUTHORIZATION = "Authorization"
+    }
+}

--- a/app/src/main/java/com/napzak/market/core/network/BaseResponse.kt
+++ b/app/src/main/java/com/napzak/market/core/network/BaseResponse.kt
@@ -1,0 +1,14 @@
+package com.napzak.market.core.network
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    @SerialName("status")
+    val status: Int,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: T,
+)

--- a/app/src/main/java/com/napzak/market/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/napzak/market/core/network/di/NetworkModule.kt
@@ -1,8 +1,11 @@
-package com.napzak.market.core.network
+package com.napzak.market.core.network.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.napzak.market.BuildConfig
 import com.napzak.market.BuildConfig.TEST_BASE_URL
+import com.napzak.market.core.network.AuthInterceptor
+import com.napzak.market.core.network.isJsonArray
+import com.napzak.market.core.network.isJsonObject
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -57,6 +60,12 @@ object NetworkModule {
         }
     }
 
+    @JWT
+    @Provides
+    @Singleton
+    fun provideJWTHttpLoggingInterceptor(authInterceptor: AuthInterceptor): Interceptor =
+        authInterceptor
+
     @Provides
     @Singleton
     fun provideOkHttpClient(
@@ -65,12 +74,34 @@ object NetworkModule {
         .addInterceptor(loggingInterceptor)
         .build()
 
+    @JWT
+    @Provides
+    @Singleton
+    fun provideJWTOkHttpClient(
+        loggingInterceptor: Interceptor,
+        authInterceptor: AuthInterceptor
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .addInterceptor(authInterceptor)
+        .build()
+
     @Provides
     fun provideRetrofit(
         client: OkHttpClient,
         factory: Converter.Factory
     ): Retrofit = Retrofit.Builder()
         .baseUrl(TEST_BASE_URL)
+        .client(client)
+        .addConverterFactory(factory)
+        .build()
+
+    @JWT
+    @Provides
+    fun provideJWTRetrofit(
+        client: OkHttpClient,
+        factory: Converter.Factory
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl("") //TODO: 서버 IP 주입
         .client(client)
         .addConverterFactory(factory)
         .build()

--- a/app/src/main/java/com/napzak/market/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/napzak/market/core/network/di/NetworkModule.kt
@@ -69,7 +69,7 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        loggingInterceptor: Interceptor
+        loggingInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .build()
@@ -79,7 +79,7 @@ object NetworkModule {
     @Singleton
     fun provideJWTOkHttpClient(
         loggingInterceptor: Interceptor,
-        authInterceptor: AuthInterceptor
+        authInterceptor: AuthInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
@@ -88,7 +88,7 @@ object NetworkModule {
     @Provides
     fun provideRetrofit(
         client: OkHttpClient,
-        factory: Converter.Factory
+        factory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(TEST_BASE_URL)
         .client(client)
@@ -99,7 +99,7 @@ object NetworkModule {
     @Provides
     fun provideJWTRetrofit(
         client: OkHttpClient,
-        factory: Converter.Factory
+        factory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl("") //TODO: 서버 IP 주입
         .client(client)

--- a/app/src/main/java/com/napzak/market/core/network/di/NetworkQualifier.kt
+++ b/app/src/main/java/com/napzak/market/core/network/di/NetworkQualifier.kt
@@ -1,0 +1,7 @@
+package com.napzak.market.core.network.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class JWT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-datastore = "1.1.1"
+datastore = "1.1.2"
 
 kotlin = "2.0.0"
 kotlinxImmutable = "0.3.7"
@@ -91,7 +91,7 @@ hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-comp
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltManager" }
 
 ## miscellaneous
-coil-compose = {group = "io.coil-kt", name="coil-compose", version.ref="coil"}
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 process-phoenix = { group = "com.jakewharton", name = "process-phoenix", version.ref = "phoenix" }


### PR DESCRIPTION
## Related issue 🛠
- closed #63 

## Work Description ✏️
- DataStore 추가 - b16aa35cf893e3290fa52cd1cfa92cbb8a95bcf4
- AuthInterceptor 추가 - 2476cda8d31f52fbf5a10d5cc2140606fe587d70
- NetworkModule 수정 - bf8850a1deea9b1030f8555c45de60d5f07ccb18
- BaseResponse 추가 - 1bf412f18e2bf4b20c6716065524f06927c78bc2

## To Reviewers 📢
- 온보딩을 제외한 모든 네트워크 통신에 토큰이 필요하여 헤더에 토큰을 추가하는 로직을 구현했습니다!
- BaseResponse도 구현했습니다! 각자 DTO 구현하면 BaseResponse 내부에 추가하여 사용하시면 됩니다!