### PR TITLE
[FIX/#101] ProductConditionType 이름 변경

### DIFF
--- a/app/src/main/java/com/napzak/market/core/type/ProductConditionType.kt
+++ b/app/src/main/java/com/napzak/market/core/type/ProductConditionType.kt
@@ -1,19 +1,19 @@
 package com.napzak.market.core.type
 
 enum class ProductConditionType(val label: String) {
-    UNUSED("미개봉"),
-    GOOD("아주 좋은 상태"),
-    SOSO("약간의 사용감"),
+    NEW("미개봉"),
+    LIKE_NEW("아주 좋은 상태"),
+    SLIGHTLY_USED("약간의 사용감"),
     USED("사용감 있음");
 
     companion object {
         fun fromCondition(condition: String?): ProductConditionType {
             return when (condition) {
-                GOOD.label -> GOOD
-                UNUSED.label -> UNUSED
-                SOSO.label -> SOSO
+                LIKE_NEW.label -> LIKE_NEW
+                NEW.label -> NEW
+                SLIGHTLY_USED.label -> SLIGHTLY_USED
                 USED.label -> USED
-                else -> UNUSED
+                else -> NEW
             }
         }
     }

--- a/app/src/main/java/com/napzak/market/presentation/registration/component/ProductConditionGridButton.kt
+++ b/app/src/main/java/com/napzak/market/presentation/registration/component/ProductConditionGridButton.kt
@@ -92,7 +92,7 @@ private const val GRID_BUTTON_COLUMN_COUNT = 2
 private fun ProductConditionGridButtonPreview() {
     NapzakMarketTheme {
         ProductConditionGridButton(
-            selectedCondition = ProductConditionType.GOOD,
+            selectedCondition = ProductConditionType.LIKE_NEW,
             onConditionSelected = {}
         )
     }

--- a/app/src/main/java/com/napzak/market/presentation/registration/component/RegistrationSellGroup.kt
+++ b/app/src/main/java/com/napzak/market/presentation/registration/component/RegistrationSellGroup.kt
@@ -131,7 +131,7 @@ private fun RegistrationSellGroupPreview() {
             salePrice = "",
             salePricePlaceHolder = "100~30,000",
             onSalePriceChange = { },
-            productCondition = ProductConditionType.GOOD,
+            productCondition = ProductConditionType.LIKE_NEW,
             onProductConditionChange = {},
             postFeeType = PostFeeType.INCLUDED,
             onPostFeeChange = {},


### PR DESCRIPTION
서버와 ENUM CLASS 일치화

## Related issue 🛠
- closed #101 

## Work Description ✏️
- 상품 등록 API 연동

## Screenshot 📸
<img src="" width="360"/>

https://github.com/user-attachments/assets/1228eb4b-211d-457a-864c-6f2f1b1b2f28

## Uncompleted Tasks 😅
- [ ] DetailPage에서 서버에서 받아오는 상품 상태가 반영 안됨

## To Reviewers 📢
직전에 작업하던 것들이.. 디벨롭에 같이 올라가서.. 이슈 다시 파서 수정 작업 진행하겠습니다 죄송합니다..
등록 시 이미지를 차례대로 S3에 등록 중인데 비동기로 처리해야할 것 같습니다. 등록에 너무 시간이 오래 걸립니다. ㅜㅜ