### PR TITLE
[UI/#113] 상세페이지 이미지 처리

### DIFF
--- a/app/src/main/java/com/napzak/market/core/type/ProductConditionType.kt
+++ b/app/src/main/java/com/napzak/market/core/type/ProductConditionType.kt
@@ -16,5 +16,15 @@ enum class ProductConditionType(val label: String) {
                 else -> NEW
             }
         }
+
+        fun fromConditionByName(condition: String?): ProductConditionType {
+            return when (condition) {
+                LIKE_NEW.name -> LIKE_NEW
+                NEW.name -> NEW
+                SLIGHTLY_USED.name -> SLIGHTLY_USED
+                USED.name -> USED
+                else -> NEW
+            }
+        }
     }
 }

--- a/app/src/main/java/com/napzak/market/presentation/detailpage/DetailPageScreen.kt
+++ b/app/src/main/java/com/napzak/market/presentation/detailpage/DetailPageScreen.kt
@@ -37,14 +37,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
@@ -62,9 +60,11 @@ import com.napzak.market.core.designsystem.component.topbar.BackTopBar
 import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.core.type.ProductConditionType
 import com.napzak.market.core.type.TradeType
+import com.napzak.market.presentation.detailpage.component.ImageBannerPager
 import com.napzak.market.presentation.detailpage.component.ProductInfoSection
 import com.napzak.market.presentation.detailpage.state.DetailPageUiState
 import com.napzak.market.presentation.detailpage.state.MarketInfoUiState
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun DetailPageRoute(
@@ -166,26 +166,18 @@ fun DetailPageScreen(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState()),
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(360.dp)
-                    .background(NapzakMarketTheme.colors.gray200),
-                contentAlignment = Alignment.Center,
-            ) {
-                uiState.productPhotoUrls.firstOrNull()?.let {
-                    AsyncImage(
-                        model = it,
-                        contentDescription = stringResource(id = R.string.detail_image_placeholder),
-                        contentScale = ContentScale.FillHeight,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } ?: Text(
-                    text = stringResource(id = R.string.detail_image_placeholder),
-                    fontSize = 16.sp,
-                    color = NapzakMarketTheme.colors.gray500,
+            ImageBannerPager(
+                bannerImages = uiState.productPhotoUrls.toImmutableList(),
+            )
+            /*uiState.productPhotoUrls.let {
+                AsyncImage(
+                    model = it,
+                    contentDescription = stringResource(id = R.string.detail_image_placeholder),
+                    contentScale = ContentScale.FillHeight,
+                    modifier = Modifier.fillMaxSize(),
                 )
-            }
+            }*/
+
 
             Spacer(modifier = Modifier.height(20.dp))
 

--- a/app/src/main/java/com/napzak/market/presentation/detailpage/DetailPageScreen.kt
+++ b/app/src/main/java/com/napzak/market/presentation/detailpage/DetailPageScreen.kt
@@ -118,7 +118,7 @@ fun DetailPageScreen(
     modifier: Modifier = Modifier,
 ) {
     val parsedTradeType = TradeType.fromName(uiState.tradeType)
-    val conditionEnum = ProductConditionType.fromCondition(uiState.productCondition)
+    val conditionEnum = ProductConditionType.fromConditionByName(uiState.productCondition)
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/napzak/market/presentation/detailpage/component/ImageBannerPager.kt
+++ b/app/src/main/java/com/napzak/market/presentation/detailpage/component/ImageBannerPager.kt
@@ -1,0 +1,117 @@
+package com.napzak.market.presentation.detailpage.component
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.napzak.market.core.designsystem.component.indicator.PageIndicator
+import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
+
+@Composable
+fun ImageBannerPager(
+    bannerImages: ImmutableList<String>,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val pagerState = rememberPagerState(
+        initialPage = BANNER_INITIAL_PAGE,
+        pageCount = { Int.MAX_VALUE },
+    )
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(BANNER_DELAY)
+            pagerState.animateScrollToPage(
+                page = pagerState.currentPage + 1,
+                animationSpec = tween(BANNER_TWEEN),
+            )
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        if (bannerImages.isNotEmpty()) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = modifier,
+            ) { page ->
+                val currentBanner = bannerImages[page % bannerImages.size]
+                AsyncImage(
+                    model = ImageRequest.Builder(context).data(currentBanner).build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.FillHeight,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = NapzakMarketTheme.colors.gray100),
+            )
+        }
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            NapzakMarketTheme.colors.black.copy(alpha = 0f),
+                            NapzakMarketTheme.colors.black.copy(alpha = 0.35f)
+                        ),
+                    )
+                ),
+        ) {
+            PageIndicator(
+                imageCount = bannerImages.size,
+                pagerState = pagerState,
+                selectedColor = NapzakMarketTheme.colors.white,
+                unselectedColor = NapzakMarketTheme.colors.gray300,
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 12.dp),
+            )
+        }
+    }
+}
+
+private const val BANNER_DELAY = 3000L
+private const val BANNER_TWEEN = 1000
+private const val BANNER_INITIAL_PAGE = 0
+
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeBannerPagerPreview() {
+    NapzakMarketTheme {
+        ImageBannerPager(
+            bannerImages = listOf<String>().toImmutableList(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(360 / 230f),
+        )
+    }
+}

--- a/app/src/main/java/com/napzak/market/presentation/detailpage/component/ImageBannerPager.kt
+++ b/app/src/main/java/com/napzak/market/presentation/detailpage/component/ImageBannerPager.kt
@@ -63,7 +63,7 @@ fun ImageBannerPager(
                 AsyncImage(
                     model = ImageRequest.Builder(context).data(currentBanner).build(),
                     contentDescription = null,
-                    contentScale = ContentScale.FillHeight,
+                    contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/com/napzak/market/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/napzak/market/presentation/splash/SplashScreen.kt
@@ -121,8 +121,6 @@ private fun SplashScreen(
                 contentPadding = PaddingValues(
                     top = 14.dp,
                     bottom = 16.dp,
-                    start = 103.dp,
-                    end = 105.dp
                 ),
                 shape = RoundedCornerShape(12.dp),
                 textStyle = NapzakMarketTheme.typography.bodyBold16,


### PR DESCRIPTION
## Related issue 🛠
- closed #113 

## Work Description ✏️
- 상세페이지 이미지 처리
- 상세페이지 물품상태 타입
- 스플래시 버튼

## Screenshot 📸

https://github.com/user-attachments/assets/54725282-be3e-4748-a74a-41a0c01ba9e1

## To Reviewers 📢
- 상세페이지 미구현 부분 구현했습니다!