### PR TITLE
[REFACTOR/#119] 탐색탭/마켓보기 UI QA 

### DIFF
--- a/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
@@ -166,9 +166,6 @@ fun GenreSearchBottomSheet(
                     }
                 }
             }
-
-            Spacer(Modifier.height(20.dp))
-
             EnableDisableTextButton(
                 text = stringResource(R.string.genre_search_apply_button),
                 isEnabled = true,
@@ -177,8 +174,6 @@ fun GenreSearchBottomSheet(
                     .fillMaxWidth()
                     .padding(20.dp),
             )
-
-            Spacer(Modifier.height(20.dp))
         }
     }
 }

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
@@ -119,7 +119,8 @@ fun GenreSearchBottomSheet(
                     is UiState.Success -> {
                         with(genreItems) {
                             LazyColumn(
-                                modifier = Modifier.padding(horizontal = 20.dp),
+                                modifier = Modifier
+                                    .padding(horizontal = 20.dp),
                             ) {
                                 itemsIndexed(
                                     items = data,
@@ -135,6 +136,12 @@ fun GenreSearchBottomSheet(
                                         },
                                         isLastItem = index == selectedGenreList.size - 1,
                                     )
+                                }
+
+                                item {
+                                    if (selectedGenreList.isNotEmpty()) {
+                                        Spacer(Modifier.height(58.dp))
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/chip/BasicChip.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/chip/BasicChip.kt
@@ -39,6 +39,7 @@ import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
  * @param leadingIcon 왼쪽에 표시할 아이콘, null이면 표시되지 않음
  * @param trailingIcon 오른쪽에 표시할 아이콘, null이면 표시되지 않음
  * @param innerPaddingValues 내부 패딩값
+ * @param onClick 해당 칩 클릭 시 실행되는 콜백
  */
 
 @Composable

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/chip/BasicChip.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/chip/BasicChip.kt
@@ -2,7 +2,6 @@ package com.napzak.market.core.designsystem.component.chip
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -24,6 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.napzak.market.core.common.extension.noRippleClickable
 import com.napzak.market.core.designsystem.component.chip.model.CustomChipColors
 import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
 
@@ -69,7 +69,7 @@ fun BasicChip(
                     )
                     .takeIf { borderWidth > 0.dp } ?: Modifier
             )
-            .clickable { onClick() }
+            .noRippleClickable(onClick)
             .padding(innerPaddingValues),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/chip/TextChip.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/chip/TextChip.kt
@@ -20,6 +20,7 @@ import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
  * @param chipColors 칩의 색상과 테두리 색상을 정의하는 CustomChipColors 객체
  * @param innerPadding 내부 패딩
  * @param shape 칩의 모양
+ * @param onClick 해당 칩 클릭 시 실행되는 콜백
  */
 
 @Composable

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/chip/TextChip.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/chip/TextChip.kt
@@ -30,6 +30,7 @@ fun TextChip(
     chipColors: CustomChipColors = CustomChipColors(),
     innerPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 5.dp),
     shape: Shape = RectangleShape,
+    onClick: () -> Unit = {},
 ) {
     BasicChip(
         text = text,
@@ -39,6 +40,7 @@ fun TextChip(
         borderWidth = 0.dp,
         innerPaddingValues = innerPadding,
         modifier = modifier,
+        onClick = onClick,
     )
 }
 

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/item/GenreSearchItem.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/item/GenreSearchItem.kt
@@ -57,7 +57,9 @@ fun GenreSearchItem(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (isGenreChipVisible) {
-            GenreTextChip()
+            GenreTextChip(
+                onGenreChipClick = onGenreItemClick
+            )
 
             Spacer(Modifier.width(8.dp))
         }

--- a/app/src/main/java/com/napzak/market/presentation/explore/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/explore/ExploreScreen.kt
@@ -297,6 +297,8 @@ fun ExploreSuccessScreen(
             onTradeTypeClick = onTradeTypeClick,
         )
 
+        Spacer(Modifier.height(1.dp))
+
         ExploreFilterGroup(
             tradeType = tradeType,
             genreList = selectedGenreList,

--- a/app/src/main/java/com/napzak/market/presentation/explore/explore/component/ProductListSection.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/explore/component/ProductListSection.kt
@@ -3,6 +3,7 @@ package com.napzak.market.presentation.explore.explore.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -28,7 +29,7 @@ fun ProductListSection(
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(20.dp),
+        contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 20.dp),
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(20.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),

--- a/app/src/main/java/com/napzak/market/presentation/explore/search/component/GenreTextChip.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/search/component/GenreTextChip.kt
@@ -14,7 +14,9 @@ import com.napzak.market.core.designsystem.component.chip.model.CustomChipColors
 import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
 
 @Composable
-fun GenreTextChip() {
+fun GenreTextChip(
+    onGenreChipClick: () -> Unit,
+) {
     TextChip(
         text = stringResource(R.string.search_genre),
         textStyle = NapzakMarketTheme.typography.capSemi12,
@@ -24,11 +26,14 @@ fun GenreTextChip() {
             containerColor = NapzakMarketTheme.colors.gray100,
         ),
         innerPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
+        onClick = onGenreChipClick
     )
 }
 
 @Preview
 @Composable
 private fun GenreTextChipPreview() {
-    GenreTextChip()
+    GenreTextChip(
+        onGenreChipClick = {},
+    )
 }

--- a/app/src/main/java/com/napzak/market/presentation/marketinfo/MarketInfoRoute.kt
+++ b/app/src/main/java/com/napzak/market/presentation/marketinfo/MarketInfoRoute.kt
@@ -209,6 +209,8 @@ fun MarketInfoSuccessScreen(
             onTradeTypeClick = onTradeTypeClick,
         )
 
+        Spacer(Modifier.height(1.dp))
+
         if (marketTab != MarketTab.REVIEW) {
             MarketFilterGroup(
                 marketTab = marketTab,


### PR DESCRIPTION
## Related issue 🛠
- closed #119 

## Work Description ✏️
- 상품갯수<->상품목록 사이 패딩 수정
- 장르검색 바텀시트 버튼 패딩 수정
- 장르검색 바텀시트 마지막 아이템 보이게 수정
- 검색화면 장르 chip 클릭 기능 추가
- 목록 탭 선택 줄 높이 수정

## Screenshot 📸

https://github.com/user-attachments/assets/c2127552-ba2a-4e30-98db-0e447c0dfbf3


## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
- 기능적 QA는 다른 이슈에서 진행할 예정입니다 
- 상점 페이지의 프로필 사진 테두리는 서버측에서 주는 이미지가 흰색 테두리를 포함하고 있어서 두꺼워보였던 이슈여서 기디측에서 이미지 새로 전달해준다고 합니다.

* 장르chip 이 core의 있는 컴포넌트부터 이슈가 있던 거라서 core 컴포넌트에 클릭 동작에 대한 함수가 추가되었습니다. 다른 파일에서 사용 시에는 문제 없게끔 default값도 지정해두었습니다.