### PR TITLE
[REFACTOR/#124] 탐색탭 내 장르 바텀시트 오류 해결 

### DIFF
--- a/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
@@ -128,7 +128,10 @@ fun GenreSearchBottomSheet(
                                     GenreSearchItem(
                                         genreName = genreItem.genreName,
                                         onGenreItemClick = {
-                                            if (selectedGenreList.size < MAX_GENRE_SELECTION) {
+                                            if (selectedGenreList.size < MAX_GENRE_SELECTION && !selectedGenreList.contains(
+                                                    genreItem
+                                                )
+                                            ) {
                                                 selectedGenreList = selectedGenreList + genreItem
                                             }
                                             focusManager.clearFocus()

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/bottomSheet/GenreSearchBottomSheet.kt
@@ -136,7 +136,7 @@ fun GenreSearchBottomSheet(
                                             }
                                             focusManager.clearFocus()
                                         },
-                                        isLastItem = index == selectedGenreList.size - 1,
+                                        isLastItem = index == genreItems.data.size - 1,
                                     )
                                 }
                             }


### PR DESCRIPTION
## Related issue 🛠
- closed #124

## Work Description ✏️
- 장르바텀시트 이미 선택된 아이템 클릭시 꺼지는 오류 해결 94b44da6b7c38bc0cffcbc40e6fa2eadbe8d1032
- 장르바텀시트 아이템 선택 시 하단 줄 사라지는 오류 해결 01e54da96153a488a8b817bac682774ebe504240

## Screenshot 📸

https://github.com/user-attachments/assets/203a3eb6-f7f7-4aa0-8c82-fe9cb4400b47



## Uncompleted Tasks 😅
- 네비게이션 로직 수정중입니다

## To Reviewers 📢
리뷰 부탁드려요