### PR TITLE
[REFACTOR/#131] qa2 explore view

### DIFF
--- a/app/src/main/java/com/napzak/market/core/designsystem/component/GenreChipButtonGroup.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/GenreChipButtonGroup.kt
@@ -8,16 +8,11 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/napzak/market/core/designsystem/component/GenreChipButtonGroup.kt
+++ b/app/src/main/java/com/napzak/market/core/designsystem/component/GenreChipButtonGroup.kt
@@ -9,11 +9,16 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -68,21 +73,32 @@ fun GenreChipButtonGroup(
                             .fillMaxWidth()
                             .background(color = backgroundColor),
                         contentPadding = contentPaddingValues,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         stickyHeader {
-                            RoundedIconButton(
-                                icon = ImageVector.vectorResource(id = R.drawable.ic_reset_18),
-                                onClick = onResetClick,
-                                modifier = Modifier.background(
-                                    color = backgroundColor,
-                                    shape = RoundedCornerShape(topEnd = 50.dp, bottomEnd = 50.dp)
+                            Row(
+                                modifier = Modifier
+                                    .background(color = backgroundColor)
+                                    .padding(end = 6.dp)
+                            ) {
+                                RoundedIconButton(
+                                    icon = ImageVector.vectorResource(id = R.drawable.ic_reset_18),
+                                    onClick = onResetClick,
+                                    modifier = Modifier
+                                        .background(
+                                            color = backgroundColor,
+                                            shape = RoundedCornerShape(
+                                                topEnd = 50.dp,
+                                                bottomEnd = 50.dp
+                                            )
+                                        )
                                 )
-                            )
+                            }
                         }
 
-                        items(genreList, key = { it.genreId }) { genre ->
+                        itemsIndexed(
+                            genreList,
+                            key = { _, genre -> genre.genreId }) { index, genre ->
                             RemovableChip(
                                 text = genre.genreName,
                                 onClick = { onGenreClick(genre) },
@@ -91,6 +107,11 @@ fun GenreChipButtonGroup(
                                         fadeInSpec = tween(CHIP_ANIMATION_DURATION),
                                         fadeOutSpec = tween(CHIP_ANIMATION_DURATION),
                                     )
+                                    .let {
+                                        if (index == 0) it.padding(start = 0.dp) else it.padding(
+                                            start = 6.dp
+                                        )
+                                    }
                             )
                         }
                     }

--- a/app/src/main/java/com/napzak/market/presentation/explore/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/explore/ExploreScreen.kt
@@ -7,15 +7,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -309,54 +306,12 @@ fun ExploreSuccessScreen(
             onUnopenClick = onUnopenClick,
         )
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 20.dp,
-                    top = 16.dp,
-                    end = 20.dp,
-                    bottom = 20.dp
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(id = R.string.explore_product),
-                style = NapzakMarketTheme.typography.bodySemi14,
-                color = NapzakMarketTheme.colors.gray900,
-            )
-
-            Spacer(Modifier.width(4.dp))
-
-            Text(
-                text = stringResource(id = R.string.explore_product_count, productList.size),
-                style = NapzakMarketTheme.typography.bodySemi14,
-                color = NapzakMarketTheme.colors.purple30,
-            )
-
-            Spacer(Modifier.weight(1f))
-
-            Row(
-                modifier = Modifier.noRippleClickable(onSortButtonClick),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = sortType.label,
-                    style = NapzakMarketTheme.typography.capMedium12,
-                    color = NapzakMarketTheme.colors.gray600,
-                )
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_down_chevron_16),
-                    contentDescription = stringResource(R.string.down_chevron_button),
-                    tint = NapzakMarketTheme.colors.gray500,
-                )
-            }
-        }
-
         ProductListSection(
             gridState = gridState,
             tradeType = tradeType,
+            sortType = sortType,
             productList = productList,
+            onSortButtonClick = onSortButtonClick,
             onItemClick = onItemClick,
             onLikeClick = onLikeClick,
         )

--- a/app/src/main/java/com/napzak/market/presentation/explore/explore/component/ProductListSection.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/explore/component/ProductListSection.kt
@@ -2,18 +2,32 @@ package com.napzak.market.presentation.explore.explore.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.napzak.market.R
+import com.napzak.market.core.common.extension.noRippleClickable
 import com.napzak.market.core.designsystem.component.item.NapzakBuyItem
 import com.napzak.market.core.designsystem.component.item.NapzakSellItem
+import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.core.type.SortType
 import com.napzak.market.core.type.TradeType
 import com.napzak.market.domain.product.model.Product
 
@@ -21,7 +35,9 @@ import com.napzak.market.domain.product.model.Product
 fun ProductListSection(
     gridState: LazyGridState,
     tradeType: TradeType,
+    sortType: SortType,
     productList: List<Product>,
+    onSortButtonClick: () -> Unit,
     onItemClick: (Long) -> Unit,
     onLikeClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -34,6 +50,47 @@ fun ProductListSection(
         horizontalArrangement = Arrangement.spacedBy(20.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
+        item(span = { GridItemSpan(2) }) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.explore_product),
+                    style = NapzakMarketTheme.typography.bodySemi14,
+                    color = NapzakMarketTheme.colors.gray900,
+                )
+
+                Spacer(Modifier.width(4.dp))
+
+                Text(
+                    text = stringResource(id = R.string.explore_product_count, productList.size),
+                    style = NapzakMarketTheme.typography.bodySemi14,
+                    color = NapzakMarketTheme.colors.purple30,
+                )
+
+                Spacer(Modifier.weight(1f))
+
+                Row(
+                    modifier = Modifier.noRippleClickable(onSortButtonClick),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = sortType.label,
+                        style = NapzakMarketTheme.typography.capMedium12,
+                        color = NapzakMarketTheme.colors.gray600,
+                    )
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_down_chevron_16),
+                        contentDescription = stringResource(R.string.down_chevron_button),
+                        tint = NapzakMarketTheme.colors.gray500,
+                    )
+                }
+            }
+        }
+
         if (tradeType == TradeType.SELL) {
             items(productList) { productItem ->
                 with(productItem) {
@@ -79,7 +136,9 @@ private fun ProductListSectionPreview(modifier: Modifier = Modifier) {
     ProductListSection(
         gridState = LazyGridState(),
         tradeType = TradeType.BUY,
+        sortType = SortType.RECENT,
         productList = emptyList(),
+        onSortButtonClick = {},
         onItemClick = { },
         onLikeClick = { _, _ -> },
         modifier = modifier,

--- a/app/src/main/java/com/napzak/market/presentation/explore/explore/component/TradeTypeTab.kt
+++ b/app/src/main/java/com/napzak/market/presentation/explore/explore/component/TradeTypeTab.kt
@@ -68,6 +68,8 @@ private fun TradeTypeTabItem(
         if (isSelected) NapzakMarketTheme.colors.purple30 else NapzakMarketTheme.colors.gray300
     val textColor =
         if (isSelected) NapzakMarketTheme.colors.purple30 else NapzakMarketTheme.colors.gray600
+    val textStyle =
+        if (isSelected) NapzakMarketTheme.typography.bodySemi16 else NapzakMarketTheme.typography.bodyMedium16
 
     Column(
         modifier = modifier
@@ -88,7 +90,7 @@ private fun TradeTypeTabItem(
     ) {
         Text(
             text = tradeType,
-            style = NapzakMarketTheme.typography.titleSemi18,
+            style = textStyle,
             color = textColor,
         )
     }

--- a/app/src/main/java/com/napzak/market/presentation/marketinfo/MarketInfoRoute.kt
+++ b/app/src/main/java/com/napzak/market/presentation/marketinfo/MarketInfoRoute.kt
@@ -2,32 +2,21 @@ package com.napzak.market.presentation.marketinfo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.napzak.market.R
-import com.napzak.market.core.common.extension.noRippleClickable
 import com.napzak.market.core.common.state.UiState
 import com.napzak.market.core.designsystem.component.image.EmptyImage
 import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
@@ -227,58 +216,12 @@ fun MarketInfoSuccessScreen(
                 is UiState.Loading -> {}
                 is UiState.Failure -> {}
                 is UiState.Success -> {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(
-                                start = 20.dp,
-                                top = 16.dp,
-                                end = 20.dp,
-                                bottom = 20.dp
-                            ),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.explore_product),
-                            style = NapzakMarketTheme.typography.bodySemi14,
-                            color = NapzakMarketTheme.colors.gray900,
-                        )
-
-                        Spacer(Modifier.width(4.dp))
-
-
-                        Text(
-                            text = stringResource(
-                                id = R.string.explore_product_count,
-                                loadProductState.data.productList.size,
-                            ),
-                            style = NapzakMarketTheme.typography.bodySemi14,
-                            color = NapzakMarketTheme.colors.purple30,
-                        )
-
-                        Spacer(Modifier.weight(1f))
-
-                        Row(
-                            modifier = Modifier.noRippleClickable(onSortButtonClick),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = sortType.label,
-                                style = NapzakMarketTheme.typography.capMedium12,
-                                color = NapzakMarketTheme.colors.gray600,
-                            )
-                            Icon(
-                                imageVector = ImageVector.vectorResource(R.drawable.ic_down_chevron_16),
-                                contentDescription = stringResource(R.string.down_chevron_button),
-                                tint = NapzakMarketTheme.colors.gray500,
-                            )
-                        }
-                    }
-
                     MarketProductListSection(
                         gridState = gridState,
                         tradeType = marketTab,
+                        sortType = sortType,
                         productList = loadProductState.data.productList,
+                        onSortButtonClick = onSortButtonClick,
                         onItemClick = onItemClick,
                         onLikeClick = onLikeClick,
                     )

--- a/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketGenreChip.kt
+++ b/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketGenreChip.kt
@@ -16,12 +16,12 @@ fun MarketGenreChip(
 ) {
     TextChip(
         text = genreName,
-        textStyle = NapzakMarketTheme.typography.capSemi12,
+        textStyle = NapzakMarketTheme.typography.capMedium12,
         modifier = Modifier.clip(RoundedCornerShape(4.dp)),
         chipColors = CustomChipColors(
             contentColor = NapzakMarketTheme.colors.gray800,
             containerColor = NapzakMarketTheme.colors.gray100,
         ),
-        innerPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
+        innerPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
     )
 }

--- a/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketProductListSection.kt
+++ b/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketProductListSection.kt
@@ -2,25 +2,42 @@ package com.napzak.market.presentation.marketinfo.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.napzak.market.R
+import com.napzak.market.core.common.extension.noRippleClickable
 import com.napzak.market.core.designsystem.component.item.NapzakBuyItem
 import com.napzak.market.core.designsystem.component.item.NapzakSellItem
+import com.napzak.market.core.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.core.type.MarketTab
+import com.napzak.market.core.type.SortType
 import com.napzak.market.domain.product.model.Product
 
 @Composable
 fun MarketProductListSection(
     gridState: LazyGridState,
     tradeType: MarketTab,
+    sortType: SortType,
     productList: List<Product>,
+    onSortButtonClick: () -> Unit,
     onItemClick: (Long) -> Unit,
     onLikeClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -28,11 +45,56 @@ fun MarketProductListSection(
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(20.dp),
+        contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 20.dp),
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(20.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
+        item(span = { GridItemSpan(2) }) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.explore_product),
+                    style = NapzakMarketTheme.typography.bodySemi14,
+                    color = NapzakMarketTheme.colors.gray900,
+                )
+
+                Spacer(Modifier.width(4.dp))
+
+
+                Text(
+                    text = stringResource(
+                        id = R.string.explore_product_count,
+                        productList.size,
+                    ),
+                    style = NapzakMarketTheme.typography.bodySemi14,
+                    color = NapzakMarketTheme.colors.purple30,
+                )
+
+                Spacer(Modifier.weight(1f))
+
+                Row(
+                    modifier = Modifier.noRippleClickable(onSortButtonClick),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = sortType.label,
+                        style = NapzakMarketTheme.typography.capMedium12,
+                        color = NapzakMarketTheme.colors.gray600,
+                    )
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_down_chevron_16),
+                        contentDescription = stringResource(R.string.down_chevron_button),
+                        tint = NapzakMarketTheme.colors.gray500,
+                    )
+                }
+            }
+        }
+
         if (tradeType == MarketTab.SELL) {
             items(productList) { productItem ->
                 with(productItem) {
@@ -76,7 +138,9 @@ private fun ProductListSectionPreview(modifier: Modifier = Modifier) {
     MarketProductListSection(
         gridState = LazyGridState(),
         tradeType = MarketTab.BUY,
+        sortType = SortType.RECENT,
         productList = emptyList(),
+        onSortButtonClick = {},
         onItemClick = { },
         onLikeClick = { _, _ -> },
         modifier = modifier,

--- a/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketTradeTypeTab.kt
+++ b/app/src/main/java/com/napzak/market/presentation/marketinfo/component/MarketTradeTypeTab.kt
@@ -77,6 +77,8 @@ private fun TradeTypeTabItem(
         if (isSelected) NapzakMarketTheme.colors.purple30 else NapzakMarketTheme.colors.gray300
     val textColor =
         if (isSelected) NapzakMarketTheme.colors.purple30 else NapzakMarketTheme.colors.gray600
+    val textStyle =
+        if (isSelected) NapzakMarketTheme.typography.bodySemi16 else NapzakMarketTheme.typography.bodyMedium16
 
     Column(
         modifier = modifier
@@ -97,7 +99,7 @@ private fun TradeTypeTabItem(
     ) {
         Text(
             text = tradeType,
-            style = NapzakMarketTheme.typography.titleSemi18,
+            style = textStyle,
             color = textColor,
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #131 

## Work Description ✏️
- 온보딩 화면에 장르 선택그룹 새로고침 버튼패딩 UI 수정 450f4a71b59e69707b078deb59b6573b84bdf57a
- 내마켓에 내 마켓 보기 버튼 vertical padding, Chip textStyle 수정 a1b975e52600f1640844279dc3763a15533cc2b5
- 내마켓에 TabRow에도 마찬가지로 textStyle 수정 4fbd20cae77550a148b0e4ce5472954c573b6899
- 탐색 내부에 LazyGrid 위에 상품개수 Row는 Sticky가 아니라 같이 올라가야함 f9044c6db589e2e2e2236fb6b9372cc85000d22b

## Screenshot 📸
<img width="464" alt="image" src="https://github.com/user-attachments/assets/9995c7a7-7097-4ce1-9b2f-1f275984e930" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/bbabe59c-1ebd-4f1f-8d10-d9f1ef6ae7f6" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/37f91661-9c39-49e0-b882-a9f6fdec275b" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/7f3b78d7-f9dd-4d55-bd36-1a3ee140f577" />


## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
리뷰 부탁핑